### PR TITLE
Make ENA 2.8.6 compile on RHEL 8.8, add ENA 2.8.7 and ixgbevf 4.17.11

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 default['ec2-drivers']['ena'] = {
-  'version'   => '2.8.6',
+  'version'   => '2.8.7',
   'install'   => true,
   'checksums' => {
     '2.2.11' => 'e01cf2456d399804593339507ebe89a197d6ed640e0730e0af25efb2681f6c60',
@@ -13,28 +13,31 @@ default['ec2-drivers']['ena'] = {
     '2.7.0'  => '74f5d86c55c7c50982c405661be613e3d2c3f28fba977743fd0b4d96fcf11d60',
     '2.7.1'  => '860119a062ef4662b05e2b270d231f588bf02b00cdeb3cef5e7cb7972449630f',
     '2.8.1'  => '527006843605f16be6344773313621b194dfbe3baead0b244f1c19069b617e87',
-    '2.8.6'  => '81bdaef76066a45c5fb41e09f398980e3540022ac95932f297900f7c6385880d'
+    '2.8.6'  => '81bdaef76066a45c5fb41e09f398980e3540022ac95932f297900f7c6385880d',
+    '2.8.7'  => '38f9cf18860c756112388a4469093218276f68d35ac173f584cc97a3c2584899'
   }
 }
 
 default['ec2-drivers']['ixgbevf'] = {
-  'version'            => '4.13.3',
+  'version'            => '4.17.11',
   'install'            => true,
   'checksums'          => {
-    '4.9.3'  => '0a74665ac3e5e41b9bb12ef06617f3019980d2a66b3d1c52c33d3845dd557013',
-    '4.10.2' => '699e9a78e474481fcbbfbad0a12d0edd704a19c6de173d3666c919c7e361868f',
-    '4.11.1' => '0031d09a54af9ecf1216c185e4641e38527643afa09e78d1bd95752e49fe8985',
-    '4.12.4' => 'd81f981dea85165057e92bd0d32c41f990890c57c35e2f0857229c9e490f7a1b',
-    '4.13.3' => 'b03010df2c491192dfda489fb6b5a99e83670ac9bc12fc76b1a144ddb2af3f76'
+    '4.9.3'   => '0a74665ac3e5e41b9bb12ef06617f3019980d2a66b3d1c52c33d3845dd557013',
+    '4.10.2'  => '699e9a78e474481fcbbfbad0a12d0edd704a19c6de173d3666c919c7e361868f',
+    '4.11.1'  => '0031d09a54af9ecf1216c185e4641e38527643afa09e78d1bd95752e49fe8985',
+    '4.12.4'  => 'd81f981dea85165057e92bd0d32c41f990890c57c35e2f0857229c9e490f7a1b',
+    '4.13.3'  => 'b03010df2c491192dfda489fb6b5a99e83670ac9bc12fc76b1a144ddb2af3f76',
+    '4.17.11' => '59813a6f92e699b4cb6983b70b91137eece4609a113fa7bb60db0be9889d2b46'
   },
   # See: https://downloadcenter.intel.com/download/18700/Ethernet-Intel-Network-Adapter-Virtual-Function-Driver-for-Intel-10-Gigabit-Ethernet-Network-Connections
   # This is the ID in the downloadmirror.intel.com download URL + /eng if it's there
   'intel_download_ids' => {
-    '4.9.3'  => '30241/eng',
-    '4.10.2' => '30274/eng',
-    '4.11.1' => '18700/eng',
-    '4.12.4' => '18700/eng',
-    '4.13.3' => '682694'
+    '4.9.3'   => '30241/eng',
+    '4.10.2'  => '30274/eng',
+    '4.11.1'  => '18700/eng',
+    '4.12.4'  => '18700/eng',
+    '4.13.3'  => '682694',
+    '4.17.11' => '773700'
   }
 }
 

--- a/files/default/ena-2.8.6-rhel-8.8.patch
+++ b/files/default/ena-2.8.6-rhel-8.8.patch
@@ -1,14 +1,27 @@
-RHEL 8.8 backported the same change as RHEL 9.2, so the check that is needed for RHEL 9.2 is also needed for RHEL 8.8.
-See: https://github.com/amzn/amzn-drivers/issues/271
+From 24c4ca96201806d81f9dbda409a5c9e892f1b300 Mon Sep 17 00:00:00 2001
+From: Keith Gable <gablk@amazon.com>
+Date: Fri, 26 May 2023 18:14:39 -0700
+Subject: [PATCH] RHEL 8.8 backported the same change as RHEL 9.2, so the check
+ that is needed for RHEL 9.2 is also needed for RHEL 8.8.
 
+See: https://github.com/amzn/amzn-drivers/issues/271
+---
+ ena/kcompat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ena/kcompat.h b/ena/kcompat.h
+index 1b3e7ed..f6ea16b 100644
 --- a/ena/kcompat.h
 +++ b/ena/kcompat.h
 @@ -1093,7 +1093,7 @@ static inline void ena_netif_napi_add(struct net_device *dev,
-                                      int (*poll)(struct napi_struct *, int))
+ 				      int (*poll)(struct napi_struct *, int))
  {
  #if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)) && \
--       !(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2)))
-+       !(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2) || RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(8, 8)))
+-	!(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2)))
++	!(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2) || RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(8, 8)))
  #ifndef NAPI_POLL_WEIGHT
  #define NAPI_POLL_WEIGHT 64
  #endif
+-- 
+2.32.1 (Apple Git-133)
+

--- a/files/default/ena-2.8.6-rhel-8.8.patch
+++ b/files/default/ena-2.8.6-rhel-8.8.patch
@@ -1,0 +1,14 @@
+RHEL 8.8 backported the same change as RHEL 9.2, so the check that is needed for RHEL 9.2 is also needed for RHEL 8.8.
+See: https://github.com/amzn/amzn-drivers/issues/271
+
+--- a/ena/kcompat.h
++++ b/ena/kcompat.h
+@@ -1093,7 +1093,7 @@ static inline void ena_netif_napi_add(struct net_device *dev,
+                                      int (*poll)(struct napi_struct *, int))
+ {
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)) && \
+-       !(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2)))
++       !(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 2) || RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(8, 8)))
+ #ifndef NAPI_POLL_WEIGHT
+ #define NAPI_POLL_WEIGHT 64
+ #endif

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'keith@art19.com'
 license          'MIT'
 description      'Cookbook that installs the latest versions of Amazon EC2 drivers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.7'
+version          '0.0.8'
 
 chef_version '>= 15' if respond_to?(:chef_version)
 issues_url 'https://github.com/art19/chef-ec2-drivers/issues' if respond_to?(:issues_url)

--- a/recipes/ena.rb
+++ b/recipes/ena.rb
@@ -46,6 +46,16 @@ if version.start_with?('2.7')
   end
 end
 
+# RHEL 9.2 changes that break ENA <2.8.6 also break RHEL 8.8
+if version == '2.8.6'
+  cookbook_file "#{Chef::Config[:file_cache_path]}/ena-rpmbuild/patches/rhel-8.8.patch" do
+    source 'ena-2.8.6-rhel-8.8.patch'
+    owner  'root'
+    group  'root'
+    mode   '0644'
+  end
+end
+
 remote_file "#{Chef::Config[:file_cache_path]}/ena-rpmbuild/amzn-drivers-ena_linux_#{version}.tar.gz" do
   source "https://github.com/amzn/amzn-drivers/archive/ena_linux_#{version}.tar.gz"
   owner  'root'

--- a/templates/default/ena.spec.erb
+++ b/templates/default/ena.spec.erb
@@ -29,6 +29,8 @@ mkdir -p %{buildroot}/usr/src/%{module}-%{version}/patches
 cp %{_topdir}/patches/kernel-5.9.patch %{buildroot}/usr/src/%{module}-%{version}/patches
 <% elsif @version.to_f == 2.7 %>
 cp %{_topdir}/patches/rhel-8.6.patch %{buildroot}/usr/src/%{module}-%{version}/patches
+<% elsif @version == "2.8.6" %>
+cp %{_topdir}/patches/rhel-8.8.patch %{buildroot}/usr/src/%{module}-%{version}/patches
 <% end %>
 cat <<'EOS' > %{buildroot}/usr/src/%{module}-%{version}/dkms.conf
 PACKAGE_NAME="ena"
@@ -45,6 +47,8 @@ PATCH[0]=kernel-5.9.patch
 PATCH_MATCH[0]=^5.9.*
 <% elsif @version.start_with?('2.7') %>
 PATCH[0]=rhel-8.6.patch
+<% elsif @version == "2.8.6" %>
+PATCH[0]=rhel-8.8.patch
 <% end %>
 EOS
 
@@ -77,6 +81,9 @@ exit 0
 exit 0
 
 %changelog
+* Fri May 26 2023 Keith Gable <gablk@amazon.com> <%= @version %>-1dkms
+- Added patch for ENA 2.8.6 to make it work on RHEL == 8.8
+
 * Mon May 23 2022 Keith Gable <gablk@amazon.com> <%= @version %>-1dkms
 - Added patch for ENA 2.7.x to make it work on RHEL >= 8.6
 


### PR DESCRIPTION
Per https://github.com/amzn/amzn-drivers/issues/271, this should be fixed in 2.8.7, so I should add that version and use it instead. Marking a draft while I make time for that.